### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,9 @@
+---
 fixtures:
   repositories:
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
-      ref: "3.2.0"
+      repo: git://github.com/puppetlabs/puppetlabs-stdlib
+      ref: 3.2.0
     file_concat: git://github.com/electrical/puppet-lib-file_concat.git
     apt: git://github.com/puppetlabs/puppetlabs-apt.git
     zypprepo: https://github.com/deadpoint/puppet-zypprepo.git


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in logstash
